### PR TITLE
[FEAT] 비밀번호 재설정 기능 구현

### DIFF
--- a/cocobob/src/api/auth.ts
+++ b/cocobob/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { LoginData, SignUpData } from '../types/types';
+import { LoginData, SignUpData, VerifyInput } from '../types/types';
 import cocobob from '../api/cocobob';
 
 //로그인
@@ -27,4 +27,22 @@ export async function check() {
       return response.data;
     });
   return response;
+}
+
+export async function findPassword(username: string) {
+  await cocobob.get(`/api/findPassword/${username}`);
+}
+
+export async function verifyCode({ username, password }: VerifyInput) {
+  await cocobob.post('/api/findPassword/verifyCode', {
+    username,
+    password,
+  });
+}
+
+export async function updatePassword({ username, password }: VerifyInput) {
+  await cocobob.post('/api/findPassword/updatePassword', {
+    username,
+    password,
+  });
 }

--- a/cocobob/src/components/auth/Login/LoginFooter.tsx
+++ b/cocobob/src/components/auth/Login/LoginFooter.tsx
@@ -56,8 +56,7 @@ const LoginFooter = () => {
         <span>아이디 저장</span>
       </CheckBoxBlock>
       <FindBlock>
-        <StyledLink to="/">아이디 찾기</StyledLink>
-        <StyledLink to="/">비밀번호 찾기</StyledLink>
+        <StyledLink to="/resetPassword">비밀번호 변경</StyledLink>
       </FindBlock>
     </LoginFooterBlock>
   );

--- a/cocobob/src/components/auth/ResetPassword/ResetPasswordButton.tsx
+++ b/cocobob/src/components/auth/ResetPassword/ResetPasswordButton.tsx
@@ -16,7 +16,7 @@ const ResetPasswordButton = ({
   return (
     <ButtonsBlock>
       <Button color={palette.main} onClick={resetPassword}>
-        다음
+        {!verify ? '다음' : '비밀번호 변경'}
       </Button>
     </ButtonsBlock>
   );

--- a/cocobob/src/components/auth/ResetPassword/ResetPasswordButton.tsx
+++ b/cocobob/src/components/auth/ResetPassword/ResetPasswordButton.tsx
@@ -4,10 +4,20 @@ import palette from '../../../lib/styles/palette';
 
 const ButtonsBlock = styled.div``;
 
-const ResetPasswordButton = () => {
+interface ResetPasswordButtonProps {
+  verify: boolean;
+  resetPassword: (e: any) => void;
+}
+
+const ResetPasswordButton = ({
+  verify,
+  resetPassword,
+}: ResetPasswordButtonProps) => {
   return (
     <ButtonsBlock>
-      <Button color={palette.main}>다음</Button>
+      <Button color={palette.main} onClick={resetPassword}>
+        다음
+      </Button>
     </ButtonsBlock>
   );
 };

--- a/cocobob/src/components/auth/ResetPassword/ResetPasswordForm.tsx
+++ b/cocobob/src/components/auth/ResetPassword/ResetPasswordForm.tsx
@@ -128,7 +128,35 @@ const ResetPasswordForm = ({
       )}
     </ResetPasswordFormBlock>
   ) : (
-    <ResetPasswordFormBlock></ResetPasswordFormBlock>
+    <ResetPasswordFormBlock>
+      <h3>비밀번호 재설정</h3>
+      <form id="resetPassword2" autoComplete="off">
+        <StyledInput
+          placeholder="비밀번호 입력"
+          name="password"
+          value={password}
+          onChange={onChange}
+          type="password"
+        />
+        <StyledInput
+          placeholder="비밀번호 재입력"
+          name="passwordConfirm"
+          value={passwordConfirm}
+          onChange={onChange}
+          type="password"
+        />
+        {checkPassword(passwordConfirm) && passwordConfirm !== '' ? (
+          <PasswordError>
+            <h4>비밀번호 불일치!</h4>
+          </PasswordError>
+        ) : (
+          <Spacer />
+        )}
+      </form>
+      {error.error?.message !== undefined && (
+        <ErrorMessage>{'비밀번호 변경  실 패 !'}</ErrorMessage>
+      )}
+    </ResetPasswordFormBlock>
   );
 };
 

--- a/cocobob/src/components/auth/ResetPassword/ResetPasswordForm.tsx
+++ b/cocobob/src/components/auth/ResetPassword/ResetPasswordForm.tsx
@@ -2,6 +2,18 @@ import styled from 'styled-components';
 import ErrorMessage from '../../common/ErrorMessage';
 import palette from '../../../lib/styles/palette';
 import Spacer from '../../common/Spacer';
+import { ResetPasswordState } from '../../../types/types';
+
+interface ResetPasswordFormProps {
+  state: ResetPasswordState;
+  email: string;
+  verification: string;
+  password: string;
+  passwordConfirm: string;
+  sendEmail: (e: any) => void;
+  onChange: (e: any) => void;
+  checkPassword: (passwordConfirm: string) => boolean;
+}
 
 const ResetPasswordFormBlock = styled.div`
   padding-bottom: 1rem;
@@ -63,6 +75,10 @@ const StyledButton = styled.button`
   justify-content: center;
   width: 3.5rem;
   height: 2rem;
+  :disabled {
+    color: red;
+    background-color: ${palette.gray[0]};
+  }
 `;
 
 const PasswordError = styled.div`
@@ -70,57 +86,49 @@ const PasswordError = styled.div`
     color: ${palette.error};
   }
 `;
-const ResetPasswordForm = () => {
-  const temp = false;
-  return temp ? (
+const ResetPasswordForm = ({
+  state,
+  email,
+  verification,
+  password,
+  passwordConfirm,
+  onChange,
+  sendEmail,
+  checkPassword,
+}: ResetPasswordFormProps) => {
+  const { error, verify, username } = state;
+
+  return !verify ? (
     <ResetPasswordFormBlock>
       <h3>비밀번호 재설정</h3>
       <form id="resetPassword1" autoComplete="off">
         <EmailDiv>
-          <EmailInput name="username" placeholder={'아이디를 입력해주세요.'} />
-          <StyledButton>전송</StyledButton>
+          <EmailInput
+            name="email"
+            placeholder={'아이디를 입력해주세요.'}
+            value={email}
+            onChange={onChange}
+          />
+          <StyledButton disabled={username === email} onClick={sendEmail}>
+            전송
+          </StyledButton>
         </EmailDiv>
         <Spacer />
         <Spacer />
         <StyledInput
-          name="certification"
+          name="verification"
           placeholder={'인증번호를 입력해주세요.'}
+          value={verification}
+          onChange={onChange}
+          disabled={username !== email}
         />
       </form>
-      {/* {error.error?.message !== undefined && (
-        <ErrorMessage>{'로 그 인 실 패 !'}</ErrorMessage>
-      )} */}
+      {error.error?.message !== undefined && (
+        <ErrorMessage>{'이메일을 다시 확인해주세요 !'}</ErrorMessage>
+      )}
     </ResetPasswordFormBlock>
   ) : (
-    <ResetPasswordFormBlock>
-      <h3>비밀번호 재설정</h3>
-      <form id="resetPassword2" autoComplete="off">
-        <StyledInput
-          placeholder="비밀번호 입력"
-          name="password"
-          // value={signUpInfo.user_pw}
-          // onChange={onChange}
-          type="password"
-        />
-        <StyledInput
-          placeholder="비밀번호 재입력"
-          name="passwordConfirm"
-          // value={passwordConfirm}
-          // onChange={onChange}
-          type="password"
-        />
-        {/* {checkPassword(passwordConfirm) && passwordConfirm !== '' ? (
-          <PasswordError>
-            <h4>비밀번호 불일치!</h4>
-          </PasswordError>
-        ) : (
-          <Spacer />
-        )} */}
-      </form>
-      {/* {error.error?.message !== undefined && (
-          <ErrorMessage>{'로 그 인 실 패 !'}</ErrorMessage>
-        )} */}
-    </ResetPasswordFormBlock>
+    <ResetPasswordFormBlock></ResetPasswordFormBlock>
   );
 };
 

--- a/cocobob/src/components/common/Button.tsx
+++ b/cocobob/src/components/common/Button.tsx
@@ -85,7 +85,6 @@ const Button = ({
   fontColor,
   opacity,
 }: ButtonProps) => {
-  console.log(children);
   return (
     <StyledButton
       color={color}

--- a/cocobob/src/features/index.ts
+++ b/cocobob/src/features/index.ts
@@ -3,6 +3,7 @@ import createSagaMiddleware from 'redux-saga';
 import { all } from 'redux-saga/effects';
 import authReducer, { check } from './auth/slices';
 import postReducer from './post/slices';
+import resetReducer from './reset/slices';
 import profileReducer from './profile/slices';
 import postsListReducer from './postsList/slices';
 import { authSaga } from '../sagas/authSaga';
@@ -14,6 +15,7 @@ const rootReducer = combineReducers({
   post: postReducer,
   profile: profileReducer,
   postsList: postsListReducer,
+  reset: resetReducer,
 });
 
 function* rootSaga() {

--- a/cocobob/src/features/reset/slices.tsx
+++ b/cocobob/src/features/reset/slices.tsx
@@ -1,0 +1,67 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AxiosError } from 'axios';
+import { ResetPasswordState, VerifyInput } from '../../types/types';
+
+const initialState: ResetPasswordState = {
+  error: {
+    loading: false,
+    error: null,
+  },
+  verify: false,
+  username: null,
+  final: false,
+};
+
+export const resetSlice = createSlice({
+  name: 'reset',
+  initialState,
+  reducers: {
+    findPassword(state, action: PayloadAction<string>) {
+      state.error.loading = true;
+    },
+    findPasswordSuccess(state, action: PayloadAction<string>) {
+      state.error.loading = false;
+      state.username = action.payload;
+    },
+    findPasswordFailure(state, action: PayloadAction<AxiosError>) {
+      state.error.loading = false;
+      state.error.error = action.payload;
+    },
+    verifyCode(state, action: PayloadAction<VerifyInput>) {
+      state.error.loading = true;
+    },
+    verifyCodeSuccess(state) {
+      state.error.loading = false;
+      state.verify = true;
+    },
+    verifyCodeFailure(state, action: PayloadAction<AxiosError>) {
+      state.error.loading = false;
+      state.error.error = action.payload;
+    },
+    updatePassword(state, action: PayloadAction<VerifyInput>) {
+      state.error.loading = true;
+    },
+    updatePasswordSuccess(state) {
+      state.error.loading = false;
+      state.final = true;
+    },
+    updatePasswordFailure(state, action: PayloadAction<AxiosError>) {
+      state.error.loading = false;
+      state.error.error = action.payload;
+    },
+  },
+});
+
+export const {
+  findPassword,
+  findPasswordSuccess,
+  findPasswordFailure,
+  verifyCode,
+  verifyCodeSuccess,
+  verifyCodeFailure,
+  updatePassword,
+  updatePasswordSuccess,
+  updatePasswordFailure,
+} = resetSlice.actions;
+
+export default resetSlice.reducer;

--- a/cocobob/src/sagas/authSaga.ts
+++ b/cocobob/src/sagas/authSaga.ts
@@ -11,6 +11,17 @@ import {
   checkFailure,
   check,
 } from '../features/auth/slices';
+import {
+  findPassword,
+  findPasswordSuccess,
+  findPasswordFailure,
+  verifyCode,
+  verifyCodeSuccess,
+  verifyCodeFailure,
+  updatePasswordSuccess,
+  updatePasswordFailure,
+  updatePassword,
+} from '../features/reset/slices';
 
 function* signUpSaga(action: ReturnType<typeof signUp>) {
   try {
@@ -41,8 +52,38 @@ function* checkSaga() {
   }
 }
 
+function* findPasswordSaga(action: ReturnType<typeof findPassword>) {
+  try {
+    yield call(authAPI.findPassword, action.payload);
+    yield put(findPasswordSuccess(action.payload));
+  } catch (e: any) {
+    yield put(findPasswordFailure(e));
+  }
+}
+
+function* verifyCodeSaga(action: ReturnType<typeof verifyCode>) {
+  try {
+    yield call(authAPI.verifyCode, action.payload);
+    yield put(verifyCodeSuccess());
+  } catch (e: any) {
+    yield put(verifyCodeFailure(e));
+  }
+}
+
+function* updatePasswordSaga(action: ReturnType<typeof updatePassword>) {
+  try {
+    yield call(authAPI.updatePassword, action.payload);
+    yield put(updatePasswordSuccess());
+  } catch (e: any) {
+    yield put(updatePasswordFailure(e));
+  }
+}
+
 export function* authSaga() {
   yield takeLatest(signUp, signUpSaga);
   yield takeLatest(login, loginSaga);
   yield takeLatest(check, checkSaga);
+  yield takeLatest(findPassword, findPasswordSaga);
+  yield takeLatest(verifyCode, verifyCodeSaga);
+  yield takeLatest(updatePassword, updatePasswordSaga);
 }

--- a/cocobob/src/types/types.tsx
+++ b/cocobob/src/types/types.tsx
@@ -73,3 +73,15 @@ export interface PostChangeData {
   contents: string;
   tag: string;
 }
+
+export interface ResetPasswordState {
+  error: ErrorData;
+  verify: boolean;
+  username: string | null;
+  final: boolean;
+}
+
+export interface VerifyInput {
+  username: string;
+  password: string;
+}


### PR DESCRIPTION
## 📌 개요
- 비밀번호 재설정 기능 구현

## 👨‍💻 작업 사항 
- [x] 이메일 전송 성공 시, 이메일 전송 버튼 disabled
- [x] 이메일 전송 성공 시, 인증 코드 입력 가능
- [x] 인증 코드 일치할 경우, 재설정할 비밀번호 입력할 수 있게 변경
- [x] 비밀번호 재설정 성공할 경우 로그인 화면으로 이동

